### PR TITLE
Feat/add kitty themes

### DIFF
--- a/extras/kitty/borrowed-mayu.conf
+++ b/extras/kitty/borrowed-mayu.conf
@@ -1,0 +1,51 @@
+# Background and foreground colors
+background #000000
+foreground #e0def4
+
+# Cursor colors
+cursor #f5dcd8
+cursor_text_color #000000
+
+# Selection colors
+selection_background #f6c177
+selection_foreground #000000
+
+# Tab bar colors
+tab_bar_background #121212
+tab_bar_margin_color #26233a
+active_tab_background #26233a
+active_tab_foreground #e0def4
+inactive_tab_background #121212
+inactive_tab_foreground #908caa
+
+# Black
+color0 #000000
+color8 #6e6a86
+
+# Red
+color1 #eb6f92
+color9 #eb6f92
+
+# Green
+color2 #3e8fb0
+color10 #3e8fb0
+
+# Yellow
+color3 #f6c177
+color11 #f6c177
+
+# Blue
+color4 #9ccfd8
+color12 #9ccfd8
+
+# Magenta
+color5 #eba4ac
+color13 #eba4ac
+
+# Cyan
+color6 #9ccfd8
+color14 #9ccfd8
+
+# White
+color7 #e0def4
+color15 #e0def4

--- a/extras/kitty/borrowed-mayu.conf
+++ b/extras/kitty/borrowed-mayu.conf
@@ -1,20 +1,20 @@
 # Background and foreground colors
 background #000000
-foreground #e0def4
+foreground #908caa
 
 # Cursor colors
 cursor #f5dcd8
 cursor_text_color #000000
 
 # Selection colors
-selection_background #f6c177
-selection_foreground #000000
+selection_background #26233a
+selection_foreground #e0def4
 
 # Tab bar colors
 tab_bar_background #121212
 tab_bar_margin_color #26233a
 active_tab_background #26233a
-active_tab_foreground #e0def4
+active_tab_foreground #eba4ac
 inactive_tab_background #121212
 inactive_tab_foreground #908caa
 

--- a/extras/kitty/borrowed-shin.conf
+++ b/extras/kitty/borrowed-shin.conf
@@ -1,0 +1,51 @@
+# Background and foreground colors
+background #000000
+foreground #e0def4
+
+# Cursor colors
+cursor #f5dcd8
+cursor_text_color #000000
+
+# Selection colors
+selection_background #f6c177
+selection_foreground #000000
+
+# Tab bar colors
+tab_bar_background #121212
+tab_bar_margin_color #26233a
+active_tab_background #26233a
+active_tab_foreground #f7c7b5
+inactive_tab_background #121212
+inactive_tab_foreground #908caa
+
+# Black
+color0 #000000
+color8 #6e6a86
+
+# Red
+color1 #e7517b
+color9 #e7517b
+
+# Green
+color2 #a37e6f
+color10 #a37e6f
+
+# Yellow
+color3 #f78273
+color11 #f78273
+
+# Blue
+color4 #949ae7
+color12 #949ae7
+
+# Magenta
+color5 #e0879e
+color13 #e0879e
+
+# Cyan
+color6 #949ae7
+color14 #949ae7
+
+c# White
+color7 #f7c7b5
+color15 #f7c7b5

--- a/extras/kitty/borrowed-shin.conf
+++ b/extras/kitty/borrowed-shin.conf
@@ -1,20 +1,20 @@
 # Background and foreground colors
 background #000000
-foreground #e0def4
+foreground #908caa
 
 # Cursor colors
 cursor #f5dcd8
 cursor_text_color #000000
 
 # Selection colors
-selection_background #f6c177
+selection_background #a37e6f
 selection_foreground #000000
 
 # Tab bar colors
 tab_bar_background #121212
 tab_bar_margin_color #26233a
 active_tab_background #26233a
-active_tab_foreground #f7c7b5
+active_tab_foreground #e0879e
 inactive_tab_background #121212
 inactive_tab_foreground #908caa
 

--- a/extras/kitty/borrowed-shin.conf
+++ b/extras/kitty/borrowed-shin.conf
@@ -46,6 +46,6 @@ color13 #e0879e
 color6 #949ae7
 color14 #949ae7
 
-c# White
+# White
 color7 #f7c7b5
 color15 #f7c7b5


### PR DESCRIPTION
Ported over the shin and mayu palettes into kitty terminal conf files for personal use. 

Figured I'd open this PR up in case you were interested in adding extras to borrowed.nvim. This follows a general format I use for my personal kitty color configs, happy to make any changes if you're interested in including.

Mayu color test:
<img width="596" alt="mayu" src="https://github.com/MyyPo/borrowed.nvim/assets/5392958/ded111f2-867a-4b4c-8e6a-436423f932f3">

Shin color test:
<img width="596" alt="shin" src="https://github.com/MyyPo/borrowed.nvim/assets/5392958/32d857f3-a8dd-4985-99aa-7bcb475edbbd">
