### PR TITLE
fix(treesitter/lsp): apply correct hls to builtin params (ts) and pun…

### DIFF
--- a/lua/borrowed/groups/modules/definitions/semantic_tokens.lua
+++ b/lua/borrowed/groups/modules/definitions/semantic_tokens.lua
@@ -30,6 +30,7 @@ function M.get(pal, spec, mod)
   res["@lsp.type.unresolvedReference"] = { link = "@error" }
   res["@lsp.type.variable"] = { link = "@variable" }
   res["@lsp.type.decorator"] = { link = "@macro" }
+  res["@lsp.type.punctuation"] = { link = "@operator" }
 
   res["@lsp.type.function"] = {} -- color functions depending on the context, sometimes they act as variables etc.
   res["@lsp.typemod.function"] = {}
@@ -63,8 +64,7 @@ function M.get(pal, spec, mod)
   res["@lsp.typemod.function.builtin.nix"] = { link = "@function" }
 
   --- Go ---
-  res["@variable.member.go"] = { link = "@variable" }
-  res["@lsp.type.variable.go"] = {}
+  res["@lsp.type.variable.go"] = {} -- Go semantic highlighting treats property access as a regular variable, so fall back to treesitter
 
   --- TS/JS ---
   res["@lsp.mod.readonly.typescript"] = {}

--- a/lua/borrowed/groups/modules/definitions/treesitter.lua
+++ b/lua/borrowed/groups/modules/definitions/treesitter.lua
@@ -17,6 +17,7 @@ function M.get(pal, spec, mod)
     ["@variable"] = { fg = syn.variable, style = stl.variables }, -- various variable names
     ["@variable.builtin"] = { fg = syn.builtin, style = stl.variables }, -- built-in variable names (e.g. `this`)
     ["@variable.parameter"] = { fg = syn.variable, stl.variables }, -- parameters of a function
+    ["@variable.parameter.builtin"] = { link = "Operator" }, -- builtin params like ... operator in Nix
     ["@variable.member"] = { fg = syn.field }, -- object and struct fields
 
     ["@constant"] = { link = "Constant" }, -- constant identifiers
@@ -138,13 +139,14 @@ function M.get(pal, spec, mod)
 
     ["@error"] = { link = "DiagnosticUnnecessary" },
 
-    -- Language specific -------------------------------------------------------
-
-    -- json
+    --- JSON ---
     ["@label.json"] = { fg = syn.func }, -- For labels: label: in C and :label: in Lua.
 
-    -- yaml
+    --- YAML ---
     ["@variable.member.yaml"] = { fg = syn.func }, -- For fields.
+
+    --- Go ---
+    ["@variable.member.go"] = { link = "@variable" }, -- Distinguish field declaration of a struct with its type
   }
 
   -- Legacy highlights


### PR DESCRIPTION
Should prevent certain operators like `...` in Nix from being being highlighted as builtins.