### PR TITLE
hotfix(lualine): temp fix, do not raise an error when grapple not ins…

### DIFF
--- a/lua/lualine/themes/borrowed-mayu.lua
+++ b/lua/lualine/themes/borrowed-mayu.lua
@@ -136,7 +136,8 @@ ins_left({
   "filename",
   cond = conditions.buffer_not_empty,
   color = function()
-    if require("grapple").exists() == true then
+    local installed_grapple, grapple = pcall(require, "grapple")
+    if installed_grapple and grapple.exists() then
       return { fg = colors.pink, gui = "bold,underline" }
     end
     return { fg = colors.pink, gui = "bold" }

--- a/lua/lualine/themes/borrowed-shin.lua
+++ b/lua/lualine/themes/borrowed-shin.lua
@@ -135,7 +135,8 @@ ins_left({
   "filename",
   cond = conditions.buffer_not_empty,
   color = function()
-    if require("grapple").exists() == true then
+    local installed_grapple, grapple = pcall(require, "grapple")
+    if installed_grapple and grapple.exists() then
       return { fg = colors.red, gui = "bold,underline" }
     end
     return { fg = colors.red, gui = "bold" }


### PR DESCRIPTION
I forgot about the second lualine module dependency: grapple. Temporary fix before an eventual proper refactor of lualines.